### PR TITLE
adds an additional condition !content.includes("\n") to check if the …

### DIFF
--- a/src/ai/responseInsertion.js
+++ b/src/ai/responseInsertion.js
@@ -353,7 +353,8 @@ export async function insertStructuredAIResponse({
   const splittedResponse = splitParagraphs(content);
   if (
     (!isResponseToSplit || splittedResponse.length === 1) &&
-    !hierarchyFlagRegex.test(splittedResponse[0])
+    !hierarchyFlagRegex.test(splittedResponse[0]) &&
+    !content.includes("\n")
   )
     if (forceInChildren)
       await createChildBlock(targetUid, content, format?.open, format?.heading);


### PR DESCRIPTION
The `insertStructuredAIResponse` function in `src/ai/responseInsertion.js`. The function is not properly handling single block responses that contain multiple lines.

The fix adds an additional condition `!content.includes("\n")` to check if the content contains any newlines. If the content has newlines, even if it's a single paragraph, it will be processed by `parseAndCreateBlocks` to properly preserve the line breaks.

This ensures that:
1. Single paragraph responses without line breaks are added directly to the block
2. Single paragraph responses with line breaks are properly parsed to preserve formatting
3. Multiple paragraph responses continue to be split into separate blocks

The issue was occurring because the function was only checking for multiple paragraphs (split by double newlines) and hierarchy markers, but not considering single paragraphs that contain line breaks. Now it will properly handle all cases of formatted text.
